### PR TITLE
Add responseHeaders to the response object

### DIFF
--- a/src/definitionGenerator.js
+++ b/src/definitionGenerator.js
@@ -266,11 +266,29 @@ class DefinitionGenerator {
                 .catch(err => {
                     throw err
                 })
+            
+            if(response.responseHeaders) {
+                obj.headers = await this.createResponseHeaders(response.responseHeaders)
+                    .catch(err => {
+                        throw err
+                    })
+            }
 
             Object.assign(responses,{[response.statusCode]: obj})
         }
 
         return responses
+    }
+    
+    async createResponseHeaders(models) {
+        const headers = {}
+        for(const model of models) {
+            headers[model.name] = {
+                schema: model.schema,
+                description: model.description
+            }
+        }
+        return headers
     }
 
     async createRequestBody(documentation) {


### PR DESCRIPTION
While using the plugin I've noticed that adding `responseHeaders` in the configuration does not add them to the final JSON. I may be wrong, but I think the property was never read. If that's the case, my suggestions aim to solve this issue.